### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,16 +4,16 @@
 # Class
 #######################################
 
-ESP_Onboarding  KEYWORD1
+ESP_Onboarding	KEYWORD1
 
 #######################################
 # Methods and Functions
 #######################################
 
-handleClient    KEYWORD2
-begin           KEYWORD2
-startServer     KEYWORD2
-getSSID         KEYWORD2
-getPassword     KEYWORD2
-getToken        KEYWORD2
-loadWifiCreds   KEYWORD2
+handleClient	KEYWORD2
+begin	KEYWORD2
+startServer	KEYWORD2
+getSSID	KEYWORD2
+getPassword	KEYWORD2
+getToken	KEYWORD2
+loadWifiCreds	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords